### PR TITLE
use shared prefix for all dashboard names

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -34,7 +34,7 @@
       'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
-    grafanaDashboardNamePrefix : "K8s /",
+    grafanaDashboardNamePrefix : "K8s / ",
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -34,6 +34,7 @@
       'pods.json': 'AMK9hS0rSbSz7cKjPHcOtk6CGHFjhSHwhbQ3sedK',
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
+    grafanaDashboardNamePrefix : "K8s /",
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -187,7 +187,7 @@ local gauge = promgrafonnet.gauge;
       ).withLowerBeingBetter();
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)s Nodes' % $._config,
+        '%(grafanaDashboardNamePrefix)sNodes' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -187,7 +187,7 @@ local gauge = promgrafonnet.gauge;
       ).withLowerBeingBetter();
 
       dashboard.new(
-        'Nodes',
+        '%(grafanaDashboardNamePrefix)s Nodes' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -60,7 +60,7 @@ local gauge = promgrafonnet.gauge;
       ));
 
       dashboard.new(
-        'Persistent Volumes',
+        '%(grafanaDashboardNamePrefix)s Persistent Volumes' % $._config,
         time_from='now-7d',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -60,7 +60,7 @@ local gauge = promgrafonnet.gauge;
       ));
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)s Persistent Volumes' % $._config,
+        '%(grafanaDashboardNamePrefix)sPersistent Volumes' % $._config,
         time_from='now-7d',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
       ).addTemplate(

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -73,7 +73,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       );
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)s Pods' % $._config,
+        '%(grafanaDashboardNamePrefix)sPods' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['pods.json']),
       ).addTemplate(

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -73,7 +73,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       );
 
       dashboard.new(
-        'Pods',
+        '%(grafanaDashboardNamePrefix)s Pods' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['pods.json']),
       ).addTemplate(

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -11,7 +11,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)s Compute Resources / Cluster' % $._config,
+        '%(grafanaDashboardNamePrefix)sCompute Resources / Cluster' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
       ).addRow(
         (g.row('Headlines') +
@@ -111,7 +111,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)s Compute Resources / Namespace' % $._config,
+        '%(grafanaDashboardNamePrefix)sCompute Resources / Namespace' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addRow(
@@ -178,7 +178,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)s Compute Resources / Pod' % $._config,
+        '%(grafanaDashboardNamePrefix)sCompute Resources / Pod' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -11,7 +11,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        'K8s / Compute Resources / Cluster',
+        '%(grafanaDashboardNamePrefix)s Compute Resources / Cluster' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
       ).addRow(
         (g.row('Headlines') +
@@ -111,7 +111,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        'K8s / Compute Resources / Namespace',
+        '%(grafanaDashboardNamePrefix)s Compute Resources / Namespace' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addRow(
@@ -178,7 +178,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       };
 
       g.dashboard(
-        'K8s / Compute Resources / Pod',
+        '%(grafanaDashboardNamePrefix)s Compute Resources / Pod' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
       ).addTemplate('namespace', 'kube_pod_info', 'namespace')
       .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -102,7 +102,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         .addPanel(replicasGraph);
 
       dashboard.new(
-        'StatefulSets',
+        '%(grafanaDashboardNamePrefix)s StatefulSets' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['statefulset.json']),
       ).addTemplate(

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -102,7 +102,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         .addPanel(replicasGraph);
 
       dashboard.new(
-        '%(grafanaDashboardNamePrefix)s StatefulSets' % $._config,
+        '%(grafanaDashboardNamePrefix)sStatefulSets' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['statefulset.json']),
       ).addTemplate(

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -6,7 +6,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
 
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)s USE Method / Cluster' % $._config,
+        '%(grafanaDashboardNamePrefix)sUSE Method / Cluster' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
       ).addRow(
         g.row('CPU')
@@ -88,7 +88,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
 
     'k8s-node-rsrc-use.json':
       g.dashboard(
-        '%(grafanaDashboardNamePrefix)s USE Method / Node' % $._config,
+        '%(grafanaDashboardNamePrefix)sUSE Method / Node' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
       ).addTemplate('node', 'kube_node_info', 'node')
       .addRow(

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -6,7 +6,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
 
       g.dashboard(
-        'K8s / USE Method / Cluster',
+        '%(grafanaDashboardNamePrefix)s USE Method / Cluster' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
       ).addRow(
         g.row('CPU')
@@ -88,7 +88,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
 
     'k8s-node-rsrc-use.json':
       g.dashboard(
-        'K8s / USE Method / Node',
+        '%(grafanaDashboardNamePrefix)s USE Method / Node' % $._config,
         uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
       ).addTemplate('node', 'kube_node_info', 'node')
       .addRow(


### PR DESCRIPTION
This way people can tell which all dashboards came from the mixin as opposed to other internally developed dashboards