### PR TITLE
remove extra label match from multiCluster queries

### DIFF
--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -21,34 +21,34 @@ local g = import 'grafana-builder/grafana.libsonnet';
          })
          .addPanel(
            g.panel('CPU Utilisation') +
-           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s=~".*"}[1m]))' % $._config)
+           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))' % $._config)
          )
         .addPanel(
           g.panel('CPU Requests Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s=~".*"}) / sum(node:node_num_cpu:sum{%(clusterLabel)s=~".*"})' % $._config)
+          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
         )
         .addPanel(
           g.panel('CPU Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s=~".*"}) / sum(node:node_num_cpu:sum{%(clusterLabel)s=~".*"})' % $._config)
+          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum{%(clusterLabel)s=~".*"}) / sum(:node_memory_MemTotal_bytes:sum{%(clusterLabel)s=~".*"})' % $._config)
+          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s=~".*"}) / sum(:node_memory_MemTotal_bytes:sum{%(clusterLabel)s=~".*"})' % $._config)
+          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
         )
         .addPanel(
           g.panel('Memory Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s=~".*"}) / sum(:node_memory_MemTotal_bytes:sum{%(clusterLabel)s=~".*"})' % $._config)
+          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
         )
       )
       .addRow(
         g.row('CPU')
         .addPanel(
           g.panel('CPU Usage') +
-          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config)
+          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config)
           + {fill: 0, linewidth: 2},
         )
       )
@@ -57,11 +57,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('CPU Quota') +
           g.tablePanel([
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'CPU Usage' },
             'Value #B': { alias: 'CPU Requests' },
@@ -76,7 +76,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('Memory Usage (w/o cache)') +
           // Not using container_memory_usage_bytes here because that includes page cache
-          g.queryPanel('sum(container_memory_rss{%(clusterLabel)s=~".*", container_name!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
+          g.queryPanel('sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes('decbytes') },
         )
       )
@@ -86,11 +86,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Requests by Namespace') +
           g.tablePanel([
             // Not using container_memory_usage_bytes here because that includes page cache
-            'sum(container_memory_rss{%(clusterLabel)s=~".*", container_name!=""}) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster"}) by (%(clusterLabel)s)' % $._config,
-            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster"}) by (%(clusterLabel)s)' % $._config,
-            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
             'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -13,12 +13,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('CPU')
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.queryPanel('sum(node:node_cpu_utilisation:avg1m{%(clusterLabel)s=~".*"} * node:node_num_cpu:sum{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) / sum(node:node_num_cpu:sum{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_cpu_utilisation:avg1m * node:node_num_cpu:sum) by (%(clusterLabel)s) / sum(node:node_num_cpu:sum) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
           g.panel('CPU Saturation (Load1)') +
-          g.queryPanel('sum(node:node_cpu_saturation_load1:{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) / sum(min(kube_pod_info{%(clusterLabel)s=~".*"}) by (node, %(clusterLabel)s)) by(%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_cpu_saturation_load1:) by (%(clusterLabel)s) / sum(min(kube_pod_info) by (node, %(clusterLabel)s)) by(%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
       )
@@ -27,12 +27,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           // the metric `node:node_memory_utilisation:ratio` is each node's portion of the total cluster utilization; just sum them
           g.panel('Memory Utilisation') +
-          g.queryPanel('sum(node:node_memory_utilisation:ratio{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_memory_utilisation:ratio) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
           g.panel('Memory Saturation (Swap I/O)') +
-          g.queryPanel('sum(node:node_memory_swap_io_bytes:sum_rate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_memory_swap_io_bytes:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
         )
       )
@@ -42,12 +42,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Disk IO Utilisation') +
           // Full utilisation would be all disks on each node spending an average of
           // 1 sec per second doing I/O, normalize by node count for stacked charts
-          g.queryPanel('sum(node:node_disk_utilisation:avg_irate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_disk_utilisation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
           g.panel('Disk IO Saturation') +
-          g.queryPanel('sum(node:node_disk_saturation:avg_irate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s) ' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_disk_saturation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s) ' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
       )
@@ -55,12 +55,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Network')
         .addPanel(
           g.panel('Net Utilisation (Transmitted)') +
-          g.queryPanel('sum(node:node_net_utilisation:sum_irate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_net_utilisation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Net Saturation (Dropped)') +
-          g.queryPanel('sum(node:node_net_saturation:sum_irate{%(clusterLabel)s=~".*"}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          g.queryPanel('sum(node:node_net_saturation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
         )
       )
@@ -70,8 +70,8 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Disk Capacity') +
           g.queryPanel(
             |||
-              sum(node_filesystem_size_bytes{%(fstypeSelector)s, %(clusterLabel)s=~".*"} - node_filesystem_avail_bytes{%(fstypeSelector)s, %(clusterLabel)s=~".*"}) by (%(clusterLabel)s)
-              / sum(node_filesystem_size_bytes{%(fstypeSelector)s, %(clusterLabel)s=~".*"}) by (%(clusterLabel)s)
+              sum(node_filesystem_size_bytes{%(fstypeSelector)s} - node_filesystem_avail_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
+              / sum(node_filesystem_size_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
             ||| % $._config, '{{node}}', legendLink
           ) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },


### PR DESCRIPTION
We don't need to be filtering by cluster=~".*" or even cluster!="" because we're already grouping by cluster label, and we'll add conditionals to hide this dashboard entirely if they don't opt-in to multi-cluster