### PR TITLE
Add dashboard tags as part of dashboard name unification

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ kubernetes {
     cadvisorSelector: 'job="kubernetes-cadvisor"',
     nodeExporterSelector: 'job="kubernetes-node-exporter"',
     kubeletSelector: 'job="kubernetes-kubelet"',
+    grafanaDashboardNamePrefix: 'Mixin / ',
   },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ TODO
 ## Customising the mixin
 
 Kubernetes-mixin allows you to override the selectors used for various jobs,
-to match those used in your Prometheus set.
+to match those used in your Prometheus set. You can also customize the dashboard
+names and add grafana tags.
 
 In a new directory, add a file `mixin.libsonnet`:
 
@@ -120,6 +121,7 @@ kubernetes {
     nodeExporterSelector: 'job="kubernetes-node-exporter"',
     kubeletSelector: 'job="kubernetes-kubelet"',
     grafanaDashboardNamePrefix: 'Mixin / ',
+    grafanaDashboardTags: ['kubernetes', 'infrastucture'],
   },
 }
 ```

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -35,6 +35,7 @@
       'statefulset.json': 'dPiBt0FRG5BNYo0XJ4L0Meoc7DWs9eL40c1CRc1g',
     },
     grafanaDashboardNamePrefix : "K8s / ",
+    grafanaDashboardTags: ["kubernetes-mixin"],
 
     // We alert when the aggregate (CPU, Memory) quota for all namespaces is
     // greater than the amount of the resources in the cluster.  We do however

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -190,6 +190,7 @@ local gauge = promgrafonnet.gauge;
         '%(grafanaDashboardNamePrefix)sNodes' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -63,6 +63,7 @@ local gauge = promgrafonnet.gauge;
         '%(grafanaDashboardNamePrefix)sPersistent Volumes' % $._config,
         time_from='now-7d',
         uid=($._config.grafanaDashboardIDs['nodes.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -76,6 +76,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         '%(grafanaDashboardNamePrefix)sPods' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['pods.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -100,7 +100,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
 
     'k8s-resources-namespace.json':
       local tableStyles = {
@@ -168,7 +168,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
 
     'k8s-resources-pod.json':
       local tableStyles = {
@@ -235,6 +235,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
             'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
           })
         )
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
   },
 }

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -105,6 +105,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         '%(grafanaDashboardNamePrefix)sStatefulSets' % $._config,
         time_from='now-1h',
         uid=($._config.grafanaDashboardIDs['statefulset.json']),
+        tags=($._config.grafanaDashboardTags),
       ).addTemplate(
         {
           current: {

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -84,7 +84,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
 
     'k8s-node-rsrc-use.json':
       g.dashboard(
@@ -156,6 +156,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
           ) +
           { yaxes: g.yaxes('percentunit') },
         ),
-      ),
+      )+{ tags: $._config.grafanaDashboardTags },
   },
 }


### PR DESCRIPTION
Define a json array of tag strings to be applied to each of the dashboards, as mentioned in upstream PR kubernetes-monitoring kubernetes-mixin pull 143.

This can be overridden with an empty array if consumer doesn't want grafana dashboard tags.