### PR TITLE
Hide the Multi-Cluster dashboards by default

### DIFF
--- a/config.libsonnet
+++ b/config.libsonnet
@@ -58,8 +58,8 @@
     // servers under some non-root path.
     grafanaPrefix: '',
 
-    //We'd like to allow users to opt-in to multiCluster dashboards (should default: false)
-    showMultiCluster: true,
+    //Opt-in to multiCluster dashboards by overriding this and the clusterLabel
+    showMultiCluster: false,
 
     // This list of filesystem is referenced in various expressions.
     fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -10,7 +10,6 @@
     kubeControllerManagerSelector: 'job="kube-controller-manager"',
     kubeApiserverSelector: 'job="kube-apiserver"',
     podLabel: 'pod',
-    clusterLabel: 'cluster',
     namespaceSelector: null,
     prefixedNamespaceSelector: if self.namespaceSelector != null then self.namespaceSelector + ',' else '',
     hostNetworkInterfaceSelector: 'device="eth0"',
@@ -60,6 +59,7 @@
 
     //Opt-in to multiCluster dashboards by overriding this and the clusterLabel
     showMultiCluster: false,
+    clusterLabel: 'cluster',
 
     // This list of filesystem is referenced in various expressions.
     fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -2,105 +2,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
 
 {
   grafanaDashboards+:: {
-    'k8s-resources-multicluster.json':
-      local tableStyles = {
-        [$._config.clusterLabel]: {
-          alias: 'Cluster',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-cluster.json') },
-        },
-      };
-
-      g.dashboard(
-        '%(grafanaDashboardNamePrefix)s  Compute Resources /  Multi-Cluster' % $._config,
-        uid=($._config.grafanaDashboardIDs['k8s-resources-multicluster.json']),
-      ).addRow(
-        (g.row('Headlines') +
-         {
-           height: '100px',
-           showTitle: false,
-         })
-         .addPanel(
-           g.panel('CPU Utilisation') +
-           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))' % $._config)
-         )
-        .addPanel(
-          g.panel('CPU Requests Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
-        )
-        .addPanel(
-          g.panel('CPU Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
-        )
-        .addPanel(
-          g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
-        )
-        .addPanel(
-          g.panel('Memory Requests Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
-        )
-        .addPanel(
-          g.panel('Memory Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
-        )
-      )
-      .addRow(
-        g.row('CPU')
-        .addPanel(
-          g.panel('CPU Usage') +
-          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config)
-          + {fill: 0, linewidth: 2},
-        )
-      )
-      .addRow(
-        g.row('CPU Quota')
-        .addPanel(
-          g.panel('CPU Quota') +
-          g.tablePanel([
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
-          ], tableStyles {
-            'Value #A': { alias: 'CPU Usage' },
-            'Value #B': { alias: 'CPU Requests' },
-            'Value #C': { alias: 'CPU Requests %', unit: 'percentunit' },
-            'Value #D': { alias: 'CPU Limits' },
-            'Value #E': { alias: 'CPU Limits %', unit: 'percentunit' },
-          })
-        )
-      )
-      .addRow(
-        g.row('Memory')
-        .addPanel(
-          g.panel('Memory Usage (w/o cache)') +
-          // Not using container_memory_usage_bytes here because that includes page cache
-          g.queryPanel('sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes('decbytes') },
-        )
-      )
-      .addRow(
-        g.row('Memory Requests')
-        .addPanel(
-          g.panel('Requests by Namespace') +
-          g.tablePanel([
-            // Not using container_memory_usage_bytes here because that includes page cache
-            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
-            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
-            'sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
-            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
-          ], tableStyles {
-            'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
-            'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
-            'Value #C': { alias: 'Memory Requests %', unit: 'percentunit' },
-            'Value #D': { alias: 'Memory Limits', unit: 'decbytes' },
-            'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
-          })
-        )
-      ),
-
     'k8s-resources-cluster.json':
       local tableStyles = {
         namespace: {
@@ -338,5 +239,105 @@ local g = import 'grafana-builder/grafana.libsonnet';
           })
         )
       ),
-  },
+  }
+  + if $._config.showMultiCluster then {
+    'k8s-resources-multicluster.json':
+      local tableStyles = {
+        [$._config.clusterLabel]: {
+          alias: 'Cluster',
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-cluster.json') },
+        },
+      };
+
+      g.dashboard(
+        '%(grafanaDashboardNamePrefix)s  Compute Resources /  Multi-Cluster' % $._config,
+        uid=($._config.grafanaDashboardIDs['k8s-resources-multicluster.json']),
+      ).addRow(
+        (g.row('Headlines') +
+         {
+           height: '100px',
+           showTitle: false,
+         })
+         .addPanel(
+           g.panel('CPU Utilisation') +
+           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))' % $._config)
+         )
+        .addPanel(
+          g.panel('CPU Requests Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('CPU Limits Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('Memory Utilisation') +
+          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('Memory Requests Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('Memory Limits Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
+        )
+      )
+      .addRow(
+        g.row('CPU')
+        .addPanel(
+          g.panel('CPU Usage') +
+          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config)
+          + {fill: 0, linewidth: 2},
+        )
+      )
+      .addRow(
+        g.row('CPU Quota')
+        .addPanel(
+          g.panel('CPU Quota') +
+          g.tablePanel([
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
+          ], tableStyles {
+            'Value #A': { alias: 'CPU Usage' },
+            'Value #B': { alias: 'CPU Requests' },
+            'Value #C': { alias: 'CPU Requests %', unit: 'percentunit' },
+            'Value #D': { alias: 'CPU Limits' },
+            'Value #E': { alias: 'CPU Limits %', unit: 'percentunit' },
+          })
+        )
+      )
+      .addRow(
+        g.row('Memory')
+        .addPanel(
+          g.panel('Memory Usage (w/o cache)') +
+          // Not using container_memory_usage_bytes here because that includes page cache
+          g.queryPanel('sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('decbytes') },
+        )
+      )
+      .addRow(
+        g.row('Memory Requests')
+        .addPanel(
+          g.panel('Requests by Namespace') +
+          g.tablePanel([
+            // Not using container_memory_usage_bytes here because that includes page cache
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
+          ], tableStyles {
+            'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
+            'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
+            'Value #C': { alias: 'Memory Requests %', unit: 'percentunit' },
+            'Value #D': { alias: 'Memory Limits', unit: 'decbytes' },
+            'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
+          })
+        )
+      ),
+  } else {},
 }

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -160,7 +160,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         ),
       ),
   }
-  + (if $._config.showMultiCluster then {
+  + if $._config.showMultiCluster then {
     'k8s-multicluster-rsrc-use.json':
       local legendLink = '%(prefix)s/d/%(uid)s/k8s-cluster-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-multicluster-rsrc-use.json') };
 
@@ -236,5 +236,5 @@ local g = import 'grafana-builder/grafana.libsonnet';
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),
       ),
-  } else {}),
+  } else {},
 }

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -2,82 +2,6 @@ local g = import 'grafana-builder/grafana.libsonnet';
 
 {
   grafanaDashboards+:: {
-    'k8s-multicluster-rsrc-use.json':
-      local legendLink = '%(prefix)s/d/%(uid)s/k8s-cluster-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-multicluster-rsrc-use.json') };
-
-      g.dashboard(
-        '%(grafanaDashboardNamePrefix)s USE Method /  Multi-Cluster' % $._config,
-        uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
-      )
-      .addRow(
-        g.row('CPU')
-        .addPanel(
-          g.panel('CPU Utilisation') +
-          g.queryPanel('sum(node:node_cpu_utilisation:avg1m * node:node_num_cpu:sum) by (%(clusterLabel)s) / sum(node:node_num_cpu:sum) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
-        )
-        .addPanel(
-          g.panel('CPU Saturation (Load1)') +
-          g.queryPanel('sum(node:node_cpu_saturation_load1:) by (%(clusterLabel)s) / sum(min(kube_pod_info) by (node, %(clusterLabel)s)) by(%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
-        )
-      )
-      .addRow(
-        g.row('Memory')
-        .addPanel(
-          // the metric `node:node_memory_utilisation:ratio` is each node's portion of the total cluster utilization; just sum them
-          g.panel('Memory Utilisation') +
-          g.queryPanel('sum(node:node_memory_utilisation:ratio) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
-        )
-        .addPanel(
-          g.panel('Memory Saturation (Swap I/O)') +
-          g.queryPanel('sum(node:node_memory_swap_io_bytes:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
-        )
-      )
-      .addRow(
-        g.row('Disk')
-        .addPanel(
-          g.panel('Disk IO Utilisation') +
-          // Full utilisation would be all disks on each node spending an average of
-          // 1 sec per second doing I/O, normalize by node count for stacked charts
-          g.queryPanel('sum(node:node_disk_utilisation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
-        )
-        .addPanel(
-          g.panel('Disk IO Saturation') +
-          g.queryPanel('sum(node:node_disk_saturation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s) ' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
-        )
-      )
-      .addRow(
-        g.row('Network')
-        .addPanel(
-          g.panel('Net Utilisation (Transmitted)') +
-          g.queryPanel('sum(node:node_net_utilisation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
-        )
-        .addPanel(
-          g.panel('Net Saturation (Dropped)') +
-          g.queryPanel('sum(node:node_net_saturation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
-        )
-      )
-      .addRow(
-        g.row('Storage')
-        .addPanel(
-          g.panel('Disk Capacity') +
-          g.queryPanel(
-            |||
-              sum(node_filesystem_size_bytes{%(fstypeSelector)s} - node_filesystem_avail_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
-              / sum(node_filesystem_size_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
-            ||| % $._config, '{{node}}', legendLink
-          ) +
-          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
-        ),
-      ),
-
     'k8s-cluster-rsrc-use.json':
       local legendLink = '%(prefix)s/d/%(uid)s/k8s-node-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-node-rsrc-use.json') };
 
@@ -235,5 +159,82 @@ local g = import 'grafana-builder/grafana.libsonnet';
           { yaxes: g.yaxes('percentunit') },
         ),
       ),
-  },
+  }
+  + (if $._config.showMultiCluster then {
+    'k8s-multicluster-rsrc-use.json':
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-cluster-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-multicluster-rsrc-use.json') };
+
+      g.dashboard(
+        '%(grafanaDashboardNamePrefix)s USE Method /  Multi-Cluster' % $._config,
+        uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
+      )
+      .addRow(
+        g.row('CPU')
+        .addPanel(
+          g.panel('CPU Utilisation') +
+          g.queryPanel('sum(node:node_cpu_utilisation:avg1m * node:node_num_cpu:sum) by (%(clusterLabel)s) / sum(node:node_num_cpu:sum) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+        .addPanel(
+          g.panel('CPU Saturation (Load1)') +
+          g.queryPanel('sum(node:node_cpu_saturation_load1:) by (%(clusterLabel)s) / sum(min(kube_pod_info) by (node, %(clusterLabel)s)) by(%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+      )
+      .addRow(
+        g.row('Memory')
+        .addPanel(
+          // the metric `node:node_memory_utilisation:ratio` is each node's portion of the total cluster utilization; just sum them
+          g.panel('Memory Utilisation') +
+          g.queryPanel('sum(node:node_memory_utilisation:ratio) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+        .addPanel(
+          g.panel('Memory Saturation (Swap I/O)') +
+          g.queryPanel('sum(node:node_memory_swap_io_bytes:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
+        )
+      )
+      .addRow(
+        g.row('Disk')
+        .addPanel(
+          g.panel('Disk IO Utilisation') +
+          // Full utilisation would be all disks on each node spending an average of
+          // 1 sec per second doing I/O, normalize by node count for stacked charts
+          g.queryPanel('sum(node:node_disk_utilisation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+        .addPanel(
+          g.panel('Disk IO Saturation') +
+          g.queryPanel('sum(node:node_disk_saturation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s) ' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+      )
+      .addRow(
+        g.row('Network')
+        .addPanel(
+          g.panel('Net Utilisation (Transmitted)') +
+          g.queryPanel('sum(node:node_net_utilisation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
+        )
+        .addPanel(
+          g.panel('Net Saturation (Dropped)') +
+          g.queryPanel('sum(node:node_net_saturation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
+        )
+      )
+      .addRow(
+        g.row('Storage')
+        .addPanel(
+          g.panel('Disk Capacity') +
+          g.queryPanel(
+            |||
+              sum(node_filesystem_size_bytes{%(fstypeSelector)s} - node_filesystem_avail_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
+              / sum(node_filesystem_size_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
+            ||| % $._config, '{{node}}', legendLink
+          ) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        ),
+      ),
+  } else {}),
 }


### PR DESCRIPTION
Move the Multi-Cluster Dashboards to end of file and hide them behind an `if showMultiCluster ...` condition.

Default the configuration to false so users must opt-in to these multi-cluster boards