### PR TITLE
Merge feature 'Multi-Cluster Dashboards' to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ $ ks apply default
 
 TODO
 
+## Multi-cluster support
+
+Kubernetes-mixin can support dashboards across multiple clusters. You need either a multi-cluster [Thanos](https://github.com/improbable-eng/thanos) installation with `external_labels` configured or a [Cortex](https://github.com/cortexproject/cortex)l system where a cluster label exists. To enable this feature you need to configure the following:
+
+```
+    //Opt-in to multiCluster dashboards by overriding this and the clusterLabel
+    showMultiCluster: true,
+    clusterLabel: '<your cluster label>',
+```
+
 ## Customising the mixin
 
 Kubernetes-mixin allows you to override the selectors used for various jobs,

--- a/config.libsonnet
+++ b/config.libsonnet
@@ -25,9 +25,11 @@
 
     // Grafana dashboard IDs are necessary for stable links for dashboards
     grafanaDashboardIDs: {
+      'k8s-resources-multicluster.json': '1gBgaexoVZ4TpBNAt2eGRsc4LNjNhdjcZd6cqU6S',
       'k8s-resources-cluster.json': 'ZnbvYbcXkob7GLqcDPLTj1ZL4MRX87tOh8xdr831',
       'k8s-resources-namespace.json': 'XaY4UCP3J51an4ikqtkUGBSjLpDW4pg39xe2FuxP',
       'k8s-resources-pod.json': 'wU56sdGSNYZTL3eO0db3pONtVmTvsyV7w8aadbYF',
+      'k8s-multicluster-rsrc-use.json': 'NJ9AlnsObVgj9uKiJMeAqfzMi1wihOMupcsDhlhR',
       'k8s-cluster-rsrc-use.json': 'uXQldxzqUNgIOUX6FyZNvqgP2vgYb78daNu4GiDc',
       'k8s-node-rsrc-use.json': 'E577CMUOwmPsxVVqM9lj40czM1ZPjclw7hGa7OT7',
       'nodes.json': 'kcb9C2QDe4IYcjiTOmYyfhsImuzxRcvwWC3YLJPS',
@@ -53,6 +55,10 @@
     // For links between grafana dashboards, you need to tell us if your grafana
     // servers under some non-root path.
     grafanaPrefix: '',
+
+    //Opt-in to multiCluster dashboards by overriding this and the clusterLabel
+    showMultiCluster: false,
+    clusterLabel: 'clusterCHANGEME',
 
     // This list of filesystem is referenced in various expressions.
     fstypes: ['ext[234]', 'btrfs', 'xfs', 'zfs'],

--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -19,9 +19,9 @@ local gauge = promgrafonnet.gauge;
           span=6,
           format='short',
         )
-        .addTarget(prometheus.target('max(node_load1{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 1m'))
-        .addTarget(prometheus.target('max(node_load5{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 5m'))
-        .addTarget(prometheus.target('max(node_load15{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 15m'));
+        .addTarget(prometheus.target('max(node_load1{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 1m'))
+        .addTarget(prometheus.target('max(node_load5{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 5m'))
+        .addTarget(prometheus.target('max(node_load15{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 15m'));
 
       local cpuByCore =
         graphPanel.new(
@@ -30,7 +30,7 @@ local gauge = promgrafonnet.gauge;
           span=6,
           format='percentunit',
         )
-        .addTarget(prometheus.target('sum by (cpu) (irate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % $._config, legendFormat='{{cpu}}'));
+        .addTarget(prometheus.target('sum by (cpu) (irate(node_cpu_seconds_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, mode!="idle", instance="$instance"}[5m]))' % $._config, legendFormat='{{cpu}}'));
 
       local memoryGraph =
         graphPanel.new(
@@ -42,16 +42,16 @@ local gauge = promgrafonnet.gauge;
         .addTarget(prometheus.target(
           |||
             max(
-              node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"}
-              - node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}
-              - node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"}
-              - node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}
+              node_memory_MemTotal_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_memory_MemFree_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_memory_Buffers_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_memory_Cached_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
             )
           ||| % $._config, legendFormat='memory used'
         ))
-        .addTarget(prometheus.target('max(node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory buffers'))
-        .addTarget(prometheus.target('max(node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory cached'))
-        .addTarget(prometheus.target('max(node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory free'));
+        .addTarget(prometheus.target('max(node_memory_Buffers_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory buffers'))
+        .addTarget(prometheus.target('max(node_memory_Cached_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory cached'))
+        .addTarget(prometheus.target('max(node_memory_MemFree_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='memory free'));
 
       local memoryGauge = gauge.new(
         'Memory Usage',
@@ -59,12 +59,12 @@ local gauge = promgrafonnet.gauge;
           max(
             (
               (
-                node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"}
-              - node_memory_MemFree_bytes{%(nodeExporterSelector)s, instance="$instance"}
-              - node_memory_Buffers_bytes{%(nodeExporterSelector)s, instance="$instance"}
-              - node_memory_Cached_bytes{%(nodeExporterSelector)s, instance="$instance"}
+                node_memory_MemTotal_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_memory_MemFree_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_memory_Buffers_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_memory_Cached_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
               )
-              / node_memory_MemTotal_bytes{%(nodeExporterSelector)s, instance="$instance"}
+              / node_memory_MemTotal_bytes{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
             ) * 100)
         ||| % $._config,
       ).withLowerBeingBetter();
@@ -88,7 +88,7 @@ local gauge = promgrafonnet.gauge;
         legend_rightSide='true',
       ).addTarget(prometheus.target(
         |||
-          max (sum by (cpu) (irate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!="idle", instance="$instance"}[2m])) ) * 100
+          max (sum by (cpu) (irate(node_cpu_seconds_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, mode!="idle", instance="$instance"}[2m])) ) * 100
         ||| % $._config,
         legendFormat='{{ cpu }}',
         intervalFactor=10,
@@ -97,7 +97,7 @@ local gauge = promgrafonnet.gauge;
       local cpuGauge = gauge.new(
         'CPU Usage',
         |||
-          avg(sum by (cpu) (irate(node_cpu_seconds_total{%(nodeExporterSelector)s, mode!="idle", instance="$instance"}[2m]))) * 100
+          avg(sum by (cpu) (irate(node_cpu_seconds_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, mode!="idle", instance="$instance"}[2m]))) * 100
         ||| % $._config,
       ).withLowerBeingBetter();
 
@@ -107,9 +107,9 @@ local gauge = promgrafonnet.gauge;
           datasource='$datasource',
           span=6,
         )
-        .addTarget(prometheus.target('max(rate(node_disk_read_bytes_total{%(nodeExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='read'))
-        .addTarget(prometheus.target('max(rate(node_disk_written_bytes_total{%(nodeExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='written'))
-        .addTarget(prometheus.target('max(rate(node_disk_io_time_seconds_total{%(nodeExporterSelector)s,  instance="$instance"}[2m]))' % $._config, legendFormat='io time')) +
+        .addTarget(prometheus.target('max(rate(node_disk_read_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='read'))
+        .addTarget(prometheus.target('max(rate(node_disk_written_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}[2m]))' % $._config, legendFormat='written'))
+        .addTarget(prometheus.target('max(rate(node_disk_io_time_seconds_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s,  instance="$instance"}[2m]))' % $._config, legendFormat='io time')) +
         {
           seriesOverrides: [
             {
@@ -132,10 +132,7 @@ local gauge = promgrafonnet.gauge;
         datasource='$datasource',
         span=6,
         format='percentunit',
-      ).addTarget(prometheus.target(
-        |||
-          node:node_filesystem_usage:
-        ||| % $._config, legendFormat='{{device}}',
+      ).addTarget(prometheus.target('node:node_filesystem_usage:{%(clusterLabel)s="$cluster"}' % $._config, legendFormat='{{device}}',
       ));
 
       local networkReceived =
@@ -145,7 +142,7 @@ local gauge = promgrafonnet.gauge;
           span=6,
           format='bytes',
         )
-        .addTarget(prometheus.target('max(rate(node_network_receive_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m]))' % $._config, legendFormat='{{device}}'));
+        .addTarget(prometheus.target('max(rate(node_network_receive_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m]))' % $._config, legendFormat='{{device}}'));
 
       local networkTransmitted =
         graphPanel.new(
@@ -154,7 +151,7 @@ local gauge = promgrafonnet.gauge;
           span=6,
           format='bytes',
         )
-        .addTarget(prometheus.target('max(rate(node_network_transmit_bytes_total{%(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m]))' % $._config, legendFormat='{{device}}'));
+        .addTarget(prometheus.target('max(rate(node_network_transmit_bytes_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", device!~"lo"}[5m]))' % $._config, legendFormat='{{device}}'));
 
       local inodesGraph =
         graphPanel.new(
@@ -165,12 +162,12 @@ local gauge = promgrafonnet.gauge;
         .addTarget(prometheus.target(
           |||
             max(
-              node_filesystem_files{%(nodeExporterSelector)s, instance="$instance"}
-              - node_filesystem_files_free{%(nodeExporterSelector)s, instance="$instance"}
+              node_filesystem_files{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_filesystem_files_free{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
             )
           ||| % $._config, legendFormat='inodes used'
         ))
-        .addTarget(prometheus.target('max(node_filesystem_files_free{%(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='inodes free'));
+        .addTarget(prometheus.target('max(node_filesystem_files_free{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='inodes free'));
 
       local inodesGauge = gauge.new(
         'Inodes Usage',
@@ -178,10 +175,10 @@ local gauge = promgrafonnet.gauge;
           max(
             (
               (
-                node_filesystem_files{%(nodeExporterSelector)s, instance="$instance"}
-              - node_filesystem_files_free{%(nodeExporterSelector)s, instance="$instance"}
+                node_filesystem_files{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
+              - node_filesystem_files_free{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
               )
-              / node_filesystem_files{%(nodeExporterSelector)s, instance="$instance"}
+              / node_filesystem_files{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"}
             ) * 100)
         ||| % $._config,
       ).withLowerBeingBetter();
@@ -208,9 +205,19 @@ local gauge = promgrafonnet.gauge;
       )
       .addTemplate(
         template.new(
+          'cluster',
+          '$datasource',
+          'label_values(kube_pod_info, %s)' % $._config.clusterLabel,
+          label='cluster',
+          refresh='time',
+          hide=if $._config.showMultiCluster then '' else 'variable',
+        )
+      )
+      .addTemplate(
+        template.new(
           'instance',
           '$datasource',
-          'label_values(node_boot_time_seconds{%(nodeExporterSelector)s}, instance)' % $._config,
+          'label_values(node_boot_time_seconds{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s}, instance)' % $._config,
           refresh='time',
         )
       )

--- a/dashboards/persistentvolumesusage.libsonnet
+++ b/dashboards/persistentvolumesusage.libsonnet
@@ -29,7 +29,7 @@ local gauge = promgrafonnet.gauge;
         legend_rightSide=false,
       ).addTarget(prometheus.target(
         |||
-          (kubelet_volume_stats_capacity_bytes{%(kubeletSelector)s, persistentvolumeclaim="$volume"} - kubelet_volume_stats_available_bytes{%(kubeletSelector)s, persistentvolumeclaim="$volume"}) / kubelet_volume_stats_capacity_bytes{%(kubeletSelector)s, persistentvolumeclaim="$volume"} * 100
+          (kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, persistentvolumeclaim="$volume"} - kubelet_volume_stats_available_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, persistentvolumeclaim="$volume"}) / kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, persistentvolumeclaim="$volume"} * 100
         ||| % $._config,
         legendFormat='{{ Usage }}',
         intervalFactor=1,
@@ -53,7 +53,7 @@ local gauge = promgrafonnet.gauge;
         legend_rightSide=false,
       ).addTarget(prometheus.target(
         |||
-          kubelet_volume_stats_inodes_used{%(kubeletSelector)s, persistentvolumeclaim="$volume"} / kubelet_volume_stats_inodes{%(kubeletSelector)s, persistentvolumeclaim="$volume"} * 100
+          kubelet_volume_stats_inodes_used{%(clusterLabel)s="$cluster", %(kubeletSelector)s, persistentvolumeclaim="$volume"} / kubelet_volume_stats_inodes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, persistentvolumeclaim="$volume"} * 100
         ||| % $._config,
         legendFormat='{{ Usage }}',
         intervalFactor=1,
@@ -81,9 +81,19 @@ local gauge = promgrafonnet.gauge;
       )
       .addTemplate(
         template.new(
+          'cluster',
+          '$datasource',
+          'label_values(kubelet_volume_stats_capacity_bytes, %s)' % $._config.clusterLabel,
+          label='cluster',
+          refresh='time',
+          hide=if $._config.showMultiCluster then '' else 'variable',
+        )
+      )
+      .addTemplate(
+        template.new(
           'namespace',
           '$datasource',
-          'label_values(kubelet_volume_stats_capacity_bytes{%(kubeletSelector)s}, exported_namespace)' % $._config,
+          'label_values(kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s}, exported_namespace)' % $._config,
           label='Namespace',
           refresh='time',
         )
@@ -92,7 +102,7 @@ local gauge = promgrafonnet.gauge;
         template.new(
           'volume',
           '$datasource',
-          'label_values(kubelet_volume_stats_capacity_bytes{%(kubeletSelector)s, exported_namespace="$namespace"}, persistentvolumeclaim)' % $._config,
+          'label_values(kubelet_volume_stats_capacity_bytes{%(clusterLabel)s="$cluster", %(kubeletSelector)s, exported_namespace="$namespace"}, persistentvolumeclaim)' % $._config,
           label='PersistentVolumeClaim',
           refresh='time',
         )

--- a/dashboards/resources.libsonnet
+++ b/dashboards/resources.libsonnet
@@ -6,14 +6,15 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         namespace: {
           alias: 'Namespace',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-namespace.json') },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-namespace?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-namespace.json') },
         },
       };
 
       g.dashboard(
         'K8s / Compute Resources / Cluster',
         uid=($._config.grafanaDashboardIDs['k8s-resources-cluster.json']),
-      ).addRow(
+      ).addTemplate('cluster', 'node_cpu_seconds_total', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      .addRow(
         (g.row('Headlines') +
          {
            height: '100px',
@@ -21,34 +22,34 @@ local g = import 'grafana-builder/grafana.libsonnet';
          })
          .addPanel(
            g.panel('CPU Utilisation') +
-           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))')
+           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle", %(clusterLabel)s="$cluster"}[1m]))' % $._config)
          )
         .addPanel(
           g.panel('CPU Requests Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(node:node_num_cpu:sum)')
+          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster"}) / sum(node:node_num_cpu:sum{%(clusterLabel)s="$cluster"})' % $._config)
         )
         .addPanel(
           g.panel('CPU Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(node:node_num_cpu:sum)')
+          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster"}) / sum(node:node_num_cpu:sum{%(clusterLabel)s="$cluster"})' % $._config)
         )
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(:node_memory_MemTotal_bytes:sum)')
+          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum{%(clusterLabel)s="$cluster"}) / sum(:node_memory_MemTotal_bytes:sum{%(clusterLabel)s="$cluster"})' % $._config)
         )
         .addPanel(
           g.panel('Memory Requests Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)')
+          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster"}) / sum(:node_memory_MemTotal_bytes:sum{%(clusterLabel)s="$cluster"})' % $._config)
         )
         .addPanel(
           g.panel('Memory Limits Commitment') +
-          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)')
+          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster"}) / sum(:node_memory_MemTotal_bytes:sum{%(clusterLabel)s="$cluster"})' % $._config)
         )
       )
       .addRow(
         g.row('CPU')
         .addPanel(
           g.panel('CPU Usage') +
-          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace)', '{{namespace}}') +
+          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config, '{{namespace}}') +
           g.stack
         )
       )
@@ -57,11 +58,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('CPU Quota') +
           g.tablePanel([
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace)',
-            'sum(kube_pod_container_resource_requests_cpu_cores) by (namespace)',
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores) by (namespace)',
-            'sum(kube_pod_container_resource_limits_cpu_cores) by (namespace)',
-            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (namespace) / sum(kube_pod_container_resource_limits_cpu_cores) by (namespace)',
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster"}) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster"}) by (namespace) / sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'CPU Usage' },
             'Value #B': { alias: 'CPU Requests' },
@@ -76,7 +77,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('Memory Usage (w/o cache)') +
           // Not using container_memory_usage_bytes here because that includes page cache
-          g.queryPanel('sum(container_memory_rss{container_name!=""}) by (namespace)', '{{namespace}}') +
+          g.queryPanel('sum(container_memory_rss{%(clusterLabel)s="$cluster", container_name!=""}) by (namespace)' % $._config, '{{namespace}}') +
           g.stack +
           { yaxes: g.yaxes('decbytes') },
         )
@@ -87,11 +88,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Requests by Namespace') +
           g.tablePanel([
             // Not using container_memory_usage_bytes here because that includes page cache
-            'sum(container_memory_rss{container_name!=""}) by (namespace)',
-            'sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)',
-            'sum(container_memory_rss{container_name!=""}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes) by (namespace)',
-            'sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)',
-            'sum(container_memory_rss{container_name!=""}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes) by (namespace)',
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container_name!=""}) by (namespace)' % $._config,
+            'sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container_name!=""}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
+            'sum(container_memory_rss{%(clusterLabel)s="$cluster", container_name!=""}) by (namespace) / sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster"}) by (namespace)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
             'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
@@ -106,19 +107,20 @@ local g = import 'grafana-builder/grafana.libsonnet';
       local tableStyles = {
         pod: {
           alias: 'Pod',
-          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-pod.json') },
-        },
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-pod.json') },
+        }
       };
 
       g.dashboard(
         'K8s / Compute Resources / Namespace',
         uid=($._config.grafanaDashboardIDs['k8s-resources-namespace.json']),
-      ).addTemplate('namespace', 'kube_pod_info', 'namespace')
+      ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
       .addRow(
         g.row('CPU Usage')
         .addPanel(
           g.panel('CPU Usage') +
-          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace"}) by (pod_name)', '{{pod_name}}') +
+          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod_name)' % $._config, '{{pod_name}}') +
           g.stack,
         )
       )
@@ -127,11 +129,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('CPU Quota') +
           g.tablePanel([
-            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace"}, "pod", "$1", "pod_name", "(.*)")) by (pod)',
-            'sum(kube_pod_container_resource_requests_cpu_cores{namespace="$namespace"}) by (pod)',
-            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace"}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{namespace="$namespace"}) by (pod)',
-            'sum(kube_pod_container_resource_limits_cpu_cores{namespace="$namespace"}) by (pod)',
-            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace"}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="$namespace"}) by (pod)',
+            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace"}, "pod", "$1", "pod_name", "(.*)")) by (pod)' % $._config,
+            'sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
+            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace"}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
+            'sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
+            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace"}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'CPU Usage' },
             'Value #B': { alias: 'CPU Requests' },
@@ -145,7 +147,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Memory Usage')
         .addPanel(
           g.panel('Memory Usage') +
-          g.queryPanel('sum(container_memory_usage_bytes{namespace="$namespace", container_name!=""}) by (pod_name)', '{{pod_name}}') +
+          g.queryPanel('sum(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", container_name!=""}) by (pod_name)' % $._config, '{{pod_name}}') +
           g.stack +
           { yaxes: g.yaxes('decbytes') },
         )
@@ -155,11 +157,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('Memory Quota') +
           g.tablePanel([
-            'sum(label_replace(container_memory_usage_bytes{namespace="$namespace",container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod)',
-            'sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace"}) by (pod)',
-            'sum(label_replace(container_memory_usage_bytes{namespace="$namespace",container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace"}) by (pod)',
-            'sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace"}) by (pod)',
-            'sum(label_replace(container_memory_usage_bytes{namespace="$namespace",container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace"}) by (pod)',
+            'sum(label_replace(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod)' % $._config,
+            'sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
+            'sum(label_replace(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
+            'sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
+            'sum(label_replace(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace",container_name!=""}, "pod", "$1", "pod_name", "(.*)")) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster", namespace="$namespace"}) by (pod)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
             'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
@@ -180,13 +182,14 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         'K8s / Compute Resources / Pod',
         uid=($._config.grafanaDashboardIDs['k8s-resources-pod.json']),
-      ).addTemplate('namespace', 'kube_pod_info', 'namespace')
-      .addTemplate('pod', 'kube_pod_info{namespace="$namespace"}', 'pod')
+      ).addTemplate('cluster', 'kube_pod_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      .addTemplate('namespace', 'kube_pod_info{%(clusterLabel)s="$cluster"}' % $._config, 'namespace')
+      .addTemplate('pod', 'kube_pod_info{%(clusterLabel)s="$cluster", namespace="$namespace"}' % $._config, 'pod')
       .addRow(
         g.row('CPU Usage')
         .addPanel(
           g.panel('CPU Usage') +
-          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace", pod_name="$pod", container_name!="POD"}) by (container_name)', '{{container_name}}') +
+          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace", pod_name="$pod", container_name!="POD", %(clusterLabel)s="$cluster"}) by (container_name)' % $._config, '{{container_name}}') +
           g.stack,
         )
       )
@@ -195,11 +198,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('CPU Quota') +
           g.tablePanel([
-            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace", pod_name="$pod", container_name!="POD"}, "container", "$1", "container_name", "(.*)")) by (container)',
-            'sum(kube_pod_container_resource_requests_cpu_cores{namespace="$namespace", pod="$pod"}) by (container)',
-            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{namespace="$namespace", pod="$pod"}) by (container)',
-            'sum(kube_pod_container_resource_limits_cpu_cores{namespace="$namespace", pod="$pod"}) by (container)',
-            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="$namespace", pod="$pod"}) by (container)',
+            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod", container_name!="POD"}, "container", "$1", "container_name", "(.*)")) by (container)' % $._config,
+            'sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}) by (container)' % $._config,
+            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}) by (container)' % $._config,
+            'sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}) by (container)' % $._config,
+            'sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{%(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}) by (container)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'CPU Usage' },
             'Value #B': { alias: 'CPU Requests' },
@@ -213,7 +216,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Memory Usage')
         .addPanel(
           g.panel('Memory Usage') +
-          g.queryPanel('sum(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod", container_name!="POD", container_name!=""}) by (container_name)', '{{container_name}}') +
+          g.queryPanel('sum(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod", container_name!="POD", container_name!=""}) by (container_name)' % $._config, '{{container_name}}') +
           g.stack,
         )
       )
@@ -222,11 +225,11 @@ local g = import 'grafana-builder/grafana.libsonnet';
         .addPanel(
           g.panel('Memory Quota') +
           g.tablePanel([
-            'sum(label_replace(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod", container_name!="POD", container_name!=""}, "container", "$1", "container_name", "(.*)")) by (container)',
-            'sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)',
-            'sum(label_replace(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)',
-            'sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace", pod="$pod", container!=""}) by (container)',
-            'sum(label_replace(container_memory_usage_bytes{namespace="$namespace", pod_name="$pod", container_name!=""}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)',
+            'sum(label_replace(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod", container_name!="POD", container_name!=""}, "container", "$1", "container_name", "(.*)")) by (container)' % $._config,
+            'sum(kube_pod_container_resource_requests_memory_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod"}) by (container)' % $._config,
+            'sum(label_replace(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)' % $._config,
+            'sum(kube_pod_container_resource_limits_memory_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container!=""}) by (container)' % $._config,
+            'sum(label_replace(container_memory_usage_bytes{%(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod", container_name!=""}, "container", "$1", "container_name", "(.*)")) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace="$namespace", pod="$pod"}) by (container)' % $._config,
           ], tableStyles {
             'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
             'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
@@ -236,5 +239,105 @@ local g = import 'grafana-builder/grafana.libsonnet';
           })
         )
       ),
-  },
+  }
+  + if $._config.showMultiCluster then {
+    'k8s-resources-multicluster.json':
+      local tableStyles = {
+        [$._config.clusterLabel]: {
+          alias: 'Cluster',
+          link: '%(prefix)s/d/%(uid)s/k8s-resources-cluster?var-datasource=$datasource&var-cluster=$__cell' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-resources-cluster.json') },
+        },
+      };
+
+      g.dashboard(
+        'K8s / Compute Resources /  Multi-Cluster',
+        uid=($._config.grafanaDashboardIDs['k8s-resources-multicluster.json']),
+      ).addRow(
+        (g.row('Headlines') +
+         {
+           height: '100px',
+           showTitle: false,
+         })
+         .addPanel(
+           g.panel('CPU Utilisation') +
+           g.statPanel('1 - avg(rate(node_cpu_seconds_total{mode="idle"}[1m]))' % $._config)
+         )
+        .addPanel(
+          g.panel('CPU Requests Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_requests_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('CPU Limits Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_limits_cpu_cores) / sum(node:node_num_cpu:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('Memory Utilisation') +
+          g.statPanel('1 - sum(:node_memory_MemFreeCachedBuffers_bytes:sum) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('Memory Requests Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_requests_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
+        )
+        .addPanel(
+          g.panel('Memory Limits Commitment') +
+          g.statPanel('sum(kube_pod_container_resource_limits_memory_bytes) / sum(:node_memory_MemTotal_bytes:sum)' % $._config)
+        )
+      )
+      .addRow(
+        g.row('CPU')
+        .addPanel(
+          g.panel('CPU Usage') +
+          g.queryPanel('sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config)
+          + {fill: 0, linewidth: 2},
+        )
+      )
+      .addRow(
+        g.row('CPU Quota')
+        .addPanel(
+          g.panel('CPU Quota') +
+          g.tablePanel([
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
+            'sum(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_cpu_cores) by (%(clusterLabel)s)' % $._config,
+          ], tableStyles {
+            'Value #A': { alias: 'CPU Usage' },
+            'Value #B': { alias: 'CPU Requests' },
+            'Value #C': { alias: 'CPU Requests %', unit: 'percentunit' },
+            'Value #D': { alias: 'CPU Limits' },
+            'Value #E': { alias: 'CPU Limits %', unit: 'percentunit' },
+          })
+        )
+      )
+      .addRow(
+        g.row('Memory')
+        .addPanel(
+          g.panel('Memory Usage (w/o cache)') +
+          // Not using container_memory_usage_bytes here because that includes page cache
+          g.queryPanel('sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('decbytes') },
+        )
+      )
+      .addRow(
+        g.row('Memory Requests')
+        .addPanel(
+          g.panel('Requests by Namespace') +
+          g.tablePanel([
+            // Not using container_memory_usage_bytes here because that includes page cache
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_requests_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
+            'sum(container_memory_rss{container_name!=""}) by (%(clusterLabel)s) / sum(kube_pod_container_resource_limits_memory_bytes) by (%(clusterLabel)s)' % $._config,
+          ], tableStyles {
+            'Value #A': { alias: 'Memory Usage', unit: 'decbytes' },
+            'Value #B': { alias: 'Memory Requests', unit: 'decbytes' },
+            'Value #C': { alias: 'Memory Requests %', unit: 'percentunit' },
+            'Value #D': { alias: 'Memory Limits', unit: 'decbytes' },
+            'Value #E': { alias: 'Memory Limits %', unit: 'percentunit' },
+          })
+        )
+      ),
+  } else {},
 }

--- a/dashboards/statefulset.libsonnet
+++ b/dashboards/statefulset.libsonnet
@@ -14,7 +14,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local cpuStat =
         numbersinglestat.new(
           'CPU',
-          'sum(rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, namespace="$namespace", pod_name=~"$statefulset.*"}[3m]))' % $._config,
+          'sum(rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name=~"$statefulset.*"}[3m]))' % $._config,
         )
         .withSpanSize(4)
         .withPostfix('cores')
@@ -23,7 +23,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local memoryStat =
         numbersinglestat.new(
           'Memory',
-          'sum(container_memory_usage_bytes{%(cadvisorSelector)s, namespace="$namespace", pod_name=~"$statefulset.*"}) / 1024^3' % $._config,
+          'sum(container_memory_usage_bytes{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name=~"$statefulset.*"}) / 1024^3' % $._config,
         )
         .withSpanSize(4)
         .withPostfix('GB')
@@ -32,7 +32,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       local networkStat =
         numbersinglestat.new(
           'Network',
-          'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, namespace="$namespace", pod_name=~"$statefulset.*"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace="$namespace",pod_name=~"$statefulset.*"}[3m]))' % $._config,
+          'sum(rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name=~"$statefulset.*"}[3m])) + sum(rate(container_network_receive_bytes_total{%(clusterLabel)s="$cluster", namespace="$namespace",pod_name=~"$statefulset.*"}[3m]))' % $._config,
         )
         .withSpanSize(4)
         .withPostfix('Bps')
@@ -46,22 +46,22 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
 
       local desiredReplicasStat = numbersinglestat.new(
         'Desired Replicas',
-        'max(kube_statefulset_replicas{%(kubeStateMetricsSelector)s, namespace="$namespace", statefulset="$statefulset"}) without (instance, pod)' % $._config,
+        'max(kube_statefulset_replicas{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", statefulset="$statefulset"}) without (instance, pod)' % $._config,
       );
 
       local availableReplicasStat = numbersinglestat.new(
         'Replicas of current version',
-        'min(kube_statefulset_status_replicas_current{%(kubeStateMetricsSelector)s, namespace="$namespace", statefulset="$statefulset"}) without (instance, pod)' % $._config,
+        'min(kube_statefulset_status_replicas_current{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", statefulset="$statefulset"}) without (instance, pod)' % $._config,
       );
 
       local observedGenerationStat = numbersinglestat.new(
         'Observed Generation',
-        'max(kube_statefulset_status_observed_generation{%(kubeStateMetricsSelector)s,  namespace="$namespace", statefulset="$statefulset"}) without (instance, pod)' % $._config,
+        'max(kube_statefulset_status_observed_generation{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", statefulset="$statefulset"}) without (instance, pod)' % $._config,
       );
 
       local metadataGenerationStat = numbersinglestat.new(
         'Metadata Generation',
-        'max(kube_statefulset_metadata_generation{%(kubeStateMetricsSelector)s, statefulset="$statefulset", namespace="$namespace"}) without (instance, pod)' % $._config,
+        'max(kube_statefulset_metadata_generation{%(kubeStateMetricsSelector)s, statefulset="$statefulset", %(clusterLabel)s="$cluster", namespace="$namespace"}) without (instance, pod)' % $._config,
       );
 
       local statsRow =
@@ -77,23 +77,23 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           datasource='$datasource',
         )
         .addTarget(prometheus.target(
-          'max(kube_statefulset_replicas{%(kubeStateMetricsSelector)s, statefulset="$statefulset",namespace="$namespace"}) without (instance, pod)' % $._config,
+          'max(kube_statefulset_replicas{%(kubeStateMetricsSelector)s, statefulset="$statefulset", %(clusterLabel)s="$cluster", namespace="$namespace"}) without (instance, pod)' % $._config,
           legendFormat='replicas specified',
         ))
         .addTarget(prometheus.target(
-          'max(kube_statefulset_status_replicas{%(kubeStateMetricsSelector)s, statefulset="$statefulset",namespace="$namespace"}) without (instance, pod)' % $._config,
+          'max(kube_statefulset_status_replicas{%(kubeStateMetricsSelector)s, statefulset="$statefulset", %(clusterLabel)s="$cluster", namespace="$namespace"}) without (instance, pod)' % $._config,
           legendFormat='replicas created',
         ))
         .addTarget(prometheus.target(
-          'min(kube_statefulset_status_replicas_ready{%(kubeStateMetricsSelector)s, statefulset="$statefulset",namespace="$namespace"}) without (instance, pod)' % $._config,
+          'min(kube_statefulset_status_replicas_ready{%(kubeStateMetricsSelector)s, statefulset="$statefulset", %(clusterLabel)s="$cluster", namespace="$namespace"}) without (instance, pod)' % $._config,
           legendFormat='ready',
         ))
         .addTarget(prometheus.target(
-          'min(kube_statefulset_status_replicas_current{%(kubeStateMetricsSelector)s, statefulset="$statefulset",namespace="$namespace"}) without (instance, pod)' % $._config,
+          'min(kube_statefulset_status_replicas_current{%(kubeStateMetricsSelector)s, statefulset="$statefulset", %(clusterLabel)s="$cluster", namespace="$namespace"}) without (instance, pod)' % $._config,
           legendFormat='replicas of current version',
         ))
         .addTarget(prometheus.target(
-          'min(kube_statefulset_status_replicas_updated{%(kubeStateMetricsSelector)s, statefulset="$statefulset",namespace="$namespace"}) without (instance, pod)' % $._config,
+          'min(kube_statefulset_status_replicas_updated{%(kubeStateMetricsSelector)s, statefulset="$statefulset", %(clusterLabel)s="$cluster", namespace="$namespace"}) without (instance, pod)' % $._config,
           legendFormat='updated',
         ));
 
@@ -120,6 +120,16 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           regex: '',
           type: 'datasource',
         },
+      )
+      .addTemplate(
+        template.new(
+          'cluster',
+          '$datasource',
+          'label_values(kube_statefulset_metadata_generation, %s)' % $._config.clusterLabel,
+          label='cluster',
+          refresh='time',
+          hide=if $._config.showMultiCluster then '' else 'variable',
+        )
       )
       .addTemplate(
         template.new(

--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -8,17 +8,18 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         'K8s / USE Method / Cluster',
         uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
-      ).addRow(
+      ).addTemplate('cluster', 'kube_node_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      .addRow(
         g.row('CPU')
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.queryPanel('node:node_cpu_utilisation:avg1m * node:node_num_cpu:sum / scalar(sum(node:node_num_cpu:sum))', '{{node}}', legendLink) +
+          g.queryPanel('node:node_cpu_utilisation:avg1m{%(clusterLabel)s="$cluster"} * node:node_num_cpu:sum{%(clusterLabel)s="$cluster"} / scalar(sum(node:node_num_cpu:sum{%(clusterLabel)s="$cluster"}))' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
           g.panel('CPU Saturation (Load1)') +
-          g.queryPanel('node:node_cpu_saturation_load1: / scalar(sum(min(kube_pod_info) by (node)))', '{{node}}', legendLink) +
+          g.queryPanel('node:node_cpu_saturation_load1:{%(clusterLabel)s="$cluster"} / scalar(sum(min(kube_pod_info{%(clusterLabel)s="$cluster"}) by (node)))' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
@@ -27,13 +28,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Memory')
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.queryPanel('node:node_memory_utilisation:ratio', '{{node}}', legendLink) +
+          g.queryPanel('node:node_memory_utilisation:ratio{%(clusterLabel)s="$cluster"}' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
           g.panel('Memory Saturation (Swap I/O)') +
-          g.queryPanel('node:node_memory_swap_io_bytes:sum_rate', '{{node}}', legendLink) +
+          g.queryPanel('node:node_memory_swap_io_bytes:sum_rate{%(clusterLabel)s="$cluster"}' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -44,13 +45,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Disk IO Utilisation') +
           // Full utilisation would be all disks on each node spending an average of
           // 1 sec per second doing I/O, normalize by node count for stacked charts
-          g.queryPanel('node:node_disk_utilisation:avg_irate / scalar(:kube_pod_info_node_count:)', '{{node}}', legendLink) +
+          g.queryPanel('node:node_disk_utilisation:avg_irate{%(clusterLabel)s="$cluster"} / scalar(:kube_pod_info_node_count:{%(clusterLabel)s="$cluster"})' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
         .addPanel(
           g.panel('Disk IO Saturation') +
-          g.queryPanel('node:node_disk_saturation:avg_irate / scalar(:kube_pod_info_node_count:)', '{{node}}', legendLink) +
+          g.queryPanel('node:node_disk_saturation:avg_irate{%(clusterLabel)s="$cluster"} / scalar(:kube_pod_info_node_count:{%(clusterLabel)s="$cluster"})' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         )
@@ -59,13 +60,13 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Network')
         .addPanel(
           g.panel('Net Utilisation (Transmitted)') +
-          g.queryPanel('node:node_net_utilisation:sum_irate', '{{node}}', legendLink) +
+          g.queryPanel('node:node_net_utilisation:sum_irate{%(clusterLabel)s="$cluster"}' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Net Saturation (Dropped)') +
-          g.queryPanel('node:node_net_saturation:sum_irate', '{{node}}', legendLink) +
+          g.queryPanel('node:node_net_saturation:sum_irate{%(clusterLabel)s="$cluster"}' % $._config, '{{node}}', legendLink) +
           g.stack +
           { yaxes: g.yaxes('Bps') },
         )
@@ -76,9 +77,9 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Disk Capacity') +
           g.queryPanel(
             |||
-              sum(max(node_filesystem_size_bytes{%(fstypeSelector)s} - node_filesystem_avail_bytes{%(fstypeSelector)s}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace)
-              / scalar(sum(max(node_filesystem_size_bytes{%(fstypeSelector)s}) by (device,%(podLabel)s,namespace)))
-              * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:
+              sum(max(node_filesystem_size_bytes{%(fstypeSelector)s, %(clusterLabel)s="$cluster"} - node_filesystem_avail_bytes{%(fstypeSelector)s, %(clusterLabel)s="$cluster"}) by (device,%(podLabel)s,namespace)) by (%(podLabel)s,namespace)
+              / scalar(sum(max(node_filesystem_size_bytes{%(fstypeSelector)s, %(clusterLabel)s="$cluster"}) by (device,%(podLabel)s,namespace)))
+              * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:{%(clusterLabel)s="$cluster"}
             ||| % $._config, '{{node}}', legendLink
           ) +
           g.stack +
@@ -90,17 +91,18 @@ local g = import 'grafana-builder/grafana.libsonnet';
       g.dashboard(
         'K8s / USE Method / Node',
         uid=($._config.grafanaDashboardIDs['k8s-node-rsrc-use.json']),
-      ).addTemplate('node', 'kube_node_info', 'node')
+      ).addTemplate('cluster', 'kube_node_info', $._config.clusterLabel, hide=if $._config.showMultiCluster then 0 else 2)
+      .addTemplate('node', 'kube_node_info{%(clusterLabel)s="$cluster"}'  % $._config, 'node')
       .addRow(
         g.row('CPU')
         .addPanel(
           g.panel('CPU Utilisation') +
-          g.queryPanel('node:node_cpu_utilisation:avg1m{node="$node"}', 'Utilisation') +
+          g.queryPanel('node:node_cpu_utilisation:avg1m{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Utilisation') +
           { yaxes: g.yaxes('percentunit') },
         )
         .addPanel(
           g.panel('CPU Saturation (Load1)') +
-          g.queryPanel('node:node_cpu_saturation_load1:{node="$node"}', 'Saturation') +
+          g.queryPanel('node:node_cpu_saturation_load1:{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Saturation') +
           { yaxes: g.yaxes('percentunit') },
         )
       )
@@ -108,12 +110,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Memory')
         .addPanel(
           g.panel('Memory Utilisation') +
-          g.queryPanel('node:node_memory_utilisation:{node="$node"}', 'Memory') +
+          g.queryPanel('node:node_memory_utilisation:{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Memory') +
           { yaxes: g.yaxes('percentunit') },
         )
         .addPanel(
           g.panel('Memory Saturation (Swap I/O)') +
-          g.queryPanel('node:node_memory_swap_io_bytes:sum_rate{node="$node"}', 'Swap IO') +
+          g.queryPanel('node:node_memory_swap_io_bytes:sum_rate{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Swap IO') +
           { yaxes: g.yaxes('Bps') },
         )
       )
@@ -121,12 +123,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Disk')
         .addPanel(
           g.panel('Disk IO Utilisation') +
-          g.queryPanel('node:node_disk_utilisation:avg_irate{node="$node"}', 'Utilisation') +
+          g.queryPanel('node:node_disk_utilisation:avg_irate{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Utilisation') +
           { yaxes: g.yaxes('percentunit') },
         )
         .addPanel(
           g.panel('Disk IO Saturation') +
-          g.queryPanel('node:node_disk_saturation:avg_irate{node="$node"}', 'Saturation') +
+          g.queryPanel('node:node_disk_saturation:avg_irate{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Saturation') +
           { yaxes: g.yaxes('percentunit') },
         )
       )
@@ -134,12 +136,12 @@ local g = import 'grafana-builder/grafana.libsonnet';
         g.row('Net')
         .addPanel(
           g.panel('Net Utilisation (Transmitted)') +
-          g.queryPanel('node:node_net_utilisation:sum_irate{node="$node"}', 'Utilisation') +
+          g.queryPanel('node:node_net_utilisation:sum_irate{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Utilisation') +
           { yaxes: g.yaxes('Bps') },
         )
         .addPanel(
           g.panel('Net Saturation (Dropped)') +
-          g.queryPanel('node:node_net_saturation:sum_irate{node="$node"}', 'Saturation') +
+          g.queryPanel('node:node_net_saturation:sum_irate{%(clusterLabel)s="$cluster", node="$node"}' % $._config, 'Saturation') +
           { yaxes: g.yaxes('Bps') },
         )
       )
@@ -149,13 +151,90 @@ local g = import 'grafana-builder/grafana.libsonnet';
           g.panel('Disk Utilisation') +
           g.queryPanel(
             |||
-              node:node_filesystem_usage:
-              * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:{node="$node"}
+              node:node_filesystem_usage:{%(clusterLabel)s="$cluster"}
+              * on (namespace, %(podLabel)s) group_left (node) node_namespace_pod:kube_pod_info:{%(clusterLabel)s="$cluster", node="$node"}
             ||| % $._config,
             '{{device}}',
           ) +
           { yaxes: g.yaxes('percentunit') },
         ),
       ),
-  },
+  }
+  + if $._config.showMultiCluster then {
+    'k8s-multicluster-rsrc-use.json':
+      local legendLink = '%(prefix)s/d/%(uid)s/k8s-cluster-rsrc-use' % { prefix: $._config.grafanaPrefix, uid: std.md5('k8s-multicluster-rsrc-use.json') };
+
+      g.dashboard(
+        'K8s / USE Method /  Multi-Cluster',
+        uid=($._config.grafanaDashboardIDs['k8s-cluster-rsrc-use.json']),
+      )
+      .addRow(
+        g.row('CPU')
+        .addPanel(
+          g.panel('CPU Utilisation') +
+          g.queryPanel('sum(node:node_cpu_utilisation:avg1m * node:node_num_cpu:sum) by (%(clusterLabel)s) / sum(node:node_num_cpu:sum) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+        .addPanel(
+          g.panel('CPU Saturation (Load1)') +
+          g.queryPanel('sum(node:node_cpu_saturation_load1:) by (%(clusterLabel)s) / sum(min(kube_pod_info) by (node, %(clusterLabel)s)) by(%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+      )
+      .addRow(
+        g.row('Memory')
+        .addPanel(
+          // the metric `node:node_memory_utilisation:ratio` is each node's portion of the total cluster utilization; just sum them
+          g.panel('Memory Utilisation') +
+          g.queryPanel('sum(node:node_memory_utilisation:ratio) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+        .addPanel(
+          g.panel('Memory Saturation (Swap I/O)') +
+          g.queryPanel('sum(node:node_memory_swap_io_bytes:sum_rate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
+        )
+      )
+      .addRow(
+        g.row('Disk')
+        .addPanel(
+          g.panel('Disk IO Utilisation') +
+          // Full utilisation would be all disks on each node spending an average of
+          // 1 sec per second doing I/O, normalize by node count for stacked charts
+          g.queryPanel('sum(node:node_disk_utilisation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+        .addPanel(
+          g.panel('Disk IO Saturation') +
+          g.queryPanel('sum(node:node_disk_saturation:avg_irate) by (%(clusterLabel)s) / sum(:kube_pod_info_node_count:) by (%(clusterLabel)s) ' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        )
+      )
+      .addRow(
+        g.row('Network')
+        .addPanel(
+          g.panel('Net Utilisation (Transmitted)') +
+          g.queryPanel('sum(node:node_net_utilisation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
+        )
+        .addPanel(
+          g.panel('Net Saturation (Dropped)') +
+          g.queryPanel('sum(node:node_net_saturation:sum_irate) by (%(clusterLabel)s)' % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes('Bps') },
+        )
+      )
+      .addRow(
+        g.row('Storage')
+        .addPanel(
+          g.panel('Disk Capacity') +
+          g.queryPanel(
+            |||
+              sum(node_filesystem_size_bytes{%(fstypeSelector)s} - node_filesystem_avail_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
+              / sum(node_filesystem_size_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
+            ||| % $._config, '{{node}}', legendLink
+          ) +
+          { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
+        ),
+      ),
+  } else {},
 }


### PR DESCRIPTION
This is the work that was demoed last week. It has been put up as an upstream PR, but we'd like to promote it to master and have addons pull from splunk/kubernetes-mixin:master

-------------------
If you are running Thanos (with external labels for clusters)
or Cortex (with a cluster label) use these dashboards to have an
overview of all the clusters in your Kubernetes environment.

The cluster label is configurable and defaults to 'cluster'.
There is a feature toggle, (showMultiCluster) that is off by default.
Enabling multiCluster will show 2 new multiCluster dashboards and
show clusters pickers on all the rest.

Note: you need head of grafana/jsonnet-libs, so jb update

Co-authored-by: Bob Cotton <bob.cotton@gmail.com>