### PR TITLE
Match on replicaset and namespace for deployment workloads

### DIFF
--- a/rules/rules.libsonnet
+++ b/rules/rules.libsonnet
@@ -76,7 +76,7 @@
                   label_replace(
                     kube_pod_owner{%(kubeStateMetricsSelector)s, owner_kind="ReplicaSet"},
                     "replicaset", "$1", "owner_name", "(.*)"
-                  ) * on(replicaset) group_left(owner_name) kube_replicaset_owner{%(kubeStateMetricsSelector)s},
+                  ) * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{%(kubeStateMetricsSelector)s},
                   "workload", "$1", "owner_name", "(.*)"
                 )
               ) by (namespace, workload, pod)


### PR DESCRIPTION
If there are replica sets in two namespaces problems happen.