### PR TITLE
Dashboard enhancements for Nodes, Pods

### DIFF
--- a/dashboards/node.libsonnet
+++ b/dashboards/node.libsonnet
@@ -21,7 +21,8 @@ local gauge = promgrafonnet.gauge;
         )
         .addTarget(prometheus.target('max(node_load1{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 1m'))
         .addTarget(prometheus.target('max(node_load5{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 5m'))
-        .addTarget(prometheus.target('max(node_load15{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 15m'));
+        .addTarget(prometheus.target('max(node_load15{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance"})' % $._config, legendFormat='load 15m'))
+        .addTarget(prometheus.target('count(node_cpu_seconds_total{%(clusterLabel)s="$cluster", %(nodeExporterSelector)s, instance="$instance", mode="user"})' % $._config, legendFormat='logical cores'));
 
       local cpuByCore =
         graphPanel.new(

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -55,8 +55,8 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           legend_avg=true,
         )
         .addTarget(prometheus.target(
-          'sum by (container_name) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="",container_name!="POD",pod_name="$pod"}[1m]))' % $._config,
-          legendFormat='{{ container_name }}',
+          'sum by (container_name) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="", container_name=~"$container", container_name!="POD",pod_name="$pod"}[1m]))' % $._config,
+          legendFormat='Usage: {{ container_name }}',
         ))
         .addTarget(prometheus.target(
           'sum by (container) (kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container=~"$container"})' % $._config,

--- a/dashboards/pods.libsonnet
+++ b/dashboards/pods.libsonnet
@@ -36,6 +36,10 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           'sum by(container) (kube_pod_container_resource_limits_memory_bytes{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container=~"$container"})' % $._config,
           legendFormat='Limit: {{ container }}',
         ))
+        .addTarget(prometheus.target(
+          'sum by(container_name) (container_memory_cache{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name=~"$pod", container_name=~"$container", container_name!="POD"})' % $._config,
+          legendFormat='Cache: {{ container_name }}',
+        ))
       );
 
       local cpuRow = row.new()
@@ -54,6 +58,14 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
           'sum by (container_name) (rate(container_cpu_usage_seconds_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", image!="",container_name!="POD",pod_name="$pod"}[1m]))' % $._config,
           legendFormat='{{ container_name }}',
         ))
+        .addTarget(prometheus.target(
+          'sum by (container) (kube_pod_container_resource_requests_cpu_cores{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container=~"$container"})' % $._config,
+          legendFormat='Requested: container = {{container}} ',
+        ))
+        .addTarget(prometheus.target(
+          'sum by (container) (kube_pod_container_resource_limits_cpu_cores{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container=~"$container"})' % $._config,
+          legendFormat='Limit: container = {{container}} ',
+        ))
       );
 
       local networkRow = row.new()
@@ -71,7 +83,30 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
         )
         .addTarget(prometheus.target(
           'sort_desc(sum by (pod_name) (rate(container_network_receive_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}[1m])))' % $._config,
-          legendFormat='{{ pod_name }}',
+          legendFormat='RX: pod = {{ pod_name }}',
+        ))
+        .addTarget(prometheus.target(
+          'sort_desc(sum by (pod_name) (rate(container_network_transmit_bytes_total{%(cadvisorSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod_name="$pod"}[1m])))' % $._config,
+          legendFormat='TX: pod = {{ pod_name }}',
+        ))
+      );
+
+      local restartsRow = row.new()
+                         .addPanel(
+        graphPanel.new(
+          'Total Restarts Per Container',
+          datasource='$datasource',
+          format='bytes',
+          min=0,
+          span=12,
+          legend_rightSide=true,
+          legend_alignAsTable=true,
+          legend_current=true,
+          legend_avg=true,
+        )
+        .addTarget(prometheus.target(
+          'max by (container) (kube_pod_container_status_restarts_total{%(kubeStateMetricsSelector)s, %(clusterLabel)s="$cluster", namespace="$namespace", pod="$pod", container=~"$container"})' % $._config,
+          legendFormat='Restarts {{ container }}',
         ))
       );
 
@@ -135,6 +170,7 @@ local numbersinglestat = promgrafonnet.numbersinglestat;
       )
       .addRow(memoryRow)
       .addRow(cpuRow)
-      .addRow(networkRow),
+      .addRow(networkRow)
+      .addRow(restartsRow),
   },
 }


### PR DESCRIPTION
Changes to Nodes:

- cpu cores added to system load graph to provide context for load1, load5, load15

Changes to Pods:

- added cached memory
- added cpu requests and limits
- added network Transmitted (prev only showed received)
- added new panel to show container restarts 
- Bug fix in Pod's cpu usage query to hide containers that weren't selected in dropdown
 
_This work will also be rebased onto upstream/master and opened as an upstream PR._
