### PR TITLE
fix legend on multi-cluster USE - disk capacity

### DIFF
--- a/dashboards/use.libsonnet
+++ b/dashboards/use.libsonnet
@@ -231,7 +231,7 @@ local g = import 'grafana-builder/grafana.libsonnet';
             |||
               sum(node_filesystem_size_bytes{%(fstypeSelector)s} - node_filesystem_avail_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
               / sum(node_filesystem_size_bytes{%(fstypeSelector)s}) by (%(clusterLabel)s)
-            ||| % $._config, '{{node}}', legendLink
+            ||| % $._config, '{{%(clusterLabel)s}}' % $._config, legendLink
           ) +
           { fill: 0, linewidth: 2, yaxes: g.yaxes({ format: 'percentunit', max: 1 }) },
         ),


### PR DESCRIPTION
This was probably a miss in the creation of cluster-level dashboard. Should be showing legend with the custom "clusterLabel" same as other panels in this dashboard.

Figure (screenshot of error):
![image](https://user-images.githubusercontent.com/5599664/53842932-1f881b00-3f5e-11e9-95b7-78e4b4ede327.png)
